### PR TITLE
Mac build fix

### DIFF
--- a/misc/mk_tioga_sty.rb
+++ b/misc/mk_tioga_sty.rb
@@ -4,7 +4,7 @@
 require 'date'
 
 # We make up the color constants from the Tioga file.
-require 'lib/Tioga/ColorConstants.rb'
+require_relative '../lib/Tioga/ColorConstants.rb'
 
 # Generate colors
 color_specs = "% Color constants, generated from ColorConstants.rb\n"

--- a/pre-setup.rb
+++ b/pre-setup.rb
@@ -4,7 +4,7 @@ require 'fileutils'
 # First, generate include files and preambles
 system "#{config("rubyprog")} misc/mk_tioga_sty.rb"
 
-if Config::CONFIG["target"] =~ /darwin/i
+if RbConfig::CONFIG["target"] =~ /darwin/i
   File.open("bin/repreview", 'w') do |f|
     f.puts '#!/bin/sh'
     f.puts "osascript #{config('bindir')}/Reload_Preview_Document.scpt $*"

--- a/setup.rb
+++ b/setup.rb
@@ -1266,6 +1266,7 @@ class Installer
   def update_shebang_line(path)
     return if no_harm?
     return if config('shebang') == 'never'
+    return if path.split('.').last == 'scpt' # don't update shebang on applescript files
     old = Shebang.load(path)
     if old
       $stderr.puts "warning: #{path}: Shebang line includes too many args.  It is not portable and your program may not work." if old.args.size > 1


### PR DESCRIPTION
Building tioga on Mac OS X 10.10 (ruby 2.0), I saw two errors and a deprecation warning:
- a require loading error described here http://rubyforge.org/pipermail/tioga-users/2013-June/000316.html
- an error trying to update the shebang of an AppleScript file
- a deprecation warning from Config -> RbConfig

These commits fix the issues.
